### PR TITLE
Fix for bug "No module named 'xdrlib'" b/c of missing library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     'pyfuse3',
     'anfs',
     'xdrlib3; python_version>="3.13"',
+    'standard-xdrlib'
 ]
 
 [project.scripts]


### PR DESCRIPTION
Hi

I have a bug because of a missing library. This PR fixes it.

## Bug Description / Steps to Reproduce

Latest Kali:

```
$ cat /etc/os-release
PRETTY_NAME="Kali GNU/Linux Rolling"
NAME="Kali GNU/Linux"
VERSION_ID="2024.4"
VERSION="2024.4"
VERSION_CODENAME=kali-rolling
ID=kali
ID_LIKE=debian
HOME_URL="https://www.kali.org/"
SUPPORT_URL="https://forums.kali.org/"
BUG_REPORT_URL="https://bugs.kali.org/"
ANSI_COLOR="1;31"

```

Latest python version from Kali repos:

```
$ python --version
Python 3.13.2
```


Install `nfs-security-tooling`:

```
pipx install git+https://github.com/hvs-consulting/nfs-security-tooling.git
```

When executing `fuse_nfs`, the module `xdrlib` is missing:

```
$ fuse_nfs
Traceback (most recent call last):
  File "/home/emanuel/.local/bin/fuse_nfs", line 5, in <module>
    from fuse_nfs.fuse_nfs import main
  File "/home/emanuel/.local/pipx/venvs/nfs-security-tooling/lib/python3.13/site-packages/fuse_nfs/fuse_nfs.py", line 25, in <module>
    from anfs.protocol.nfs3.client import NFSv3Client, NFSFileEntry
  File "/home/emanuel/.local/pipx/venvs/nfs-security-tooling/lib/python3.13/site-packages/anfs/protocol/nfs3/client.py", line 8, in <module>
    from anfs.protocol.nfs3.pack import nfs_pro_v3Packer, nfs_pro_v3Unpacker, nextiter, NFSFileEntry
  File "/home/emanuel/.local/pipx/venvs/nfs-security-tooling/lib/python3.13/site-packages/anfs/protocol/nfs3/pack.py", line 2, in <module>
    from xdrlib import Packer, Unpacker, ConversionError
ModuleNotFoundError: No module named 'xdrlib'
```

The workaround is to just install `standard-xdrlib` which provides the `xdrlib` module:

```
$ pipx inject --force nfs-security-tooling standard-xdrlib
  injected package standard-xdrlib into venv nfs_security_tooling
done! ✨ 🌟 ✨
```

After this, it works as expected:

```
$ fuse_nfs
usage: fuse_nfs [-h] (--export EXPORT | --manual-fh MANUAL_FH) [--uid UID | --fake-uid] [--fake-uid-allow-root]
                [--allow-write] [--remote-symlinks] [--unprivileged-port] [--mount-port MOUNT_PORT] [--nfs-port NFS_PORT]
                [--fix-nested-exports] [--debug] [--debug-fuse]
                mountpoint host
fuse_nfs: error: the following arguments are required: mountpoint, host
```

## Comment

I saw you recently added the `xdrlib3` as a dependency, but I still had the problem. This does not solve this problem. Not sure if ,  `xdrlib3` is required at all.

BTW, this research and the tooling is awesome 🤘.

Best,
Mänu